### PR TITLE
`:not(thead) td` does not work as expected

### DIFF
--- a/scss/themes/default/_styles.scss
+++ b/scss/themes/default/_styles.scss
@@ -196,7 +196,7 @@ table {
     }
   }
 
-  :not(thead) td {
+  :not(thead) > * > td {
     --font-size: 0.875em;
   }
 }


### PR DESCRIPTION
`table :not(thead) td`
also selects tds in thead
https://jsfiddle.net/zh8dx97b/4/

Not that specificity will not be incresed with this fix as * has zero specificity:
`:not(thead) > * > td`

Maybe `table {` could be dropped completely, since 'thead' and `td` only exist in table?