### PR TITLE
Fix typo in example code

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -609,7 +609,7 @@
 <pre><code>&lt;<b>hgroup</b>&gt;
   &lt;<b>h2</b>&gt;Heading 2&lt;/<b>h2</b>&gt;
   &lt;<b>h3</b>&gt;Subtitle for heading 2&lt;/<b>h3</b>&gt;
-&lt;<b>hgroup</b>&gt;</code></pre>
+&lt;/<b>hgroup</b>&gt;</code></pre>
 
               </footer>
             </article>


### PR DESCRIPTION
Closes the `<hgroup>` tag in the example code under Elements > Typography in the Docs.

![image](https://user-images.githubusercontent.com/271432/141868966-586c971b-ebf3-4bfe-811e-088f15e00f28.png)
