### PR TITLE
Unnecessary imports

### DIFF
--- a/scss/themes/default.scss
+++ b/scss/themes/default.scss
@@ -3,7 +3,6 @@
  */
 
 // Variables
-@import "../variables";
 @import "default/colors";
 
 // Commons styles


### PR DESCRIPTION
Import @import "../variables"; unnecessary in the file /themes/default.scss, since it is included in pico.slim.scss and pico.scss.