### PR TITLE
Allow use of custom data-theme values that also override auto light/dark switching

### DIFF
--- a/scss/themes/default.scss
+++ b/scss/themes/default.scss
@@ -17,7 +17,7 @@
 // Automatically enabled if user has Dark mode enabled
 @import "default/dark";
 @media only screen and (prefers-color-scheme: dark) {
-  :root:not([data-theme="light"]) {
+  :root:not([data-theme]) {
     @include dark;
   }
 }


### PR DESCRIPTION
I'm migrating https://github.com/immers-space/immers over to pico in order to make the style customizable for each server, and I love it. The extensive use of CSS custom properties means we can customize it at runtime without having to rebuild the web client.

We'd like to offer an additional built-in theme that is activated via `data-theme` attribute value, but we have an issue that setting `data-theme` to anything other than `light` leaves the auto light/dark switch enabled, making that particular theme unreadable for `prefers-color-scheme: dark` users.

This tiny change makes it so any value for data-theme will disable the auto-switching. All of the existing behavior is preserved:

* Users with no preference on page with no data-theme gets light mode
* Users with dark preference on page with no data-theme gets dark mode
* Users with light preference on page with no data-theme gets light mode
* `[data-theme=light]` shows light mode regardless of preference
* `[data-theme=dark]` shows dark mode regardless of preference


https://user-images.githubusercontent.com/10034859/199774465-c4e07981-c1e5-4938-a676-99ff772d6313.mp4



