### PR TITLE
docs: Fix bad path in customization

### DIFF
--- a/docs/customization.html
+++ b/docs/customization.html
@@ -53,7 +53,7 @@
 <b>@import</b> <u>"path/themes/custom"</u>;;
 
 <em>// Import needed components</em>
-<b>@import</b> <u>"@picocss/pico/scss/pico/layout/document"</u>;
-<b>@import</b> <u>"@picocss/pico/scss/pico/layout/sectioning"</u>;
+<b>@import</b> <u>"@picocss/pico/scss/layout/document"</u>;
+<b>@import</b> <u>"@picocss/pico/scss/layout/sectioning"</u>;
 <em>…</em>
 </code></pre><p>Compiling a custom SASS version allows you to create a lighter version with only the components that are useful to you. Example here: <a href="https://github.com/picocss/pico/blob/master/scss/pico.slim.scss">scss/pico.slim.scss</a>.</p></section><footer><hr><p><small>Code licensed <a href="https://github.com/picocss/pico/blob/master/LICENSE.md" class="secondary">MIT</a></small></p></footer></div></main><script src="js/commons.min.js"></script><script src="js/customization.min.js"></script></body></html>


### PR DESCRIPTION
The example on the [customization page](https://picocss.com/docs/customization.html) for importing components is wrong and should use the proper path in `node_modules`.
```diff
// Import needed components
- @import "@picocss/pico/scss/pico/layout/document";
+ @import "@picocss/pico/scss/layout/document";
- @import "@picocss/pico/scss/pico/layout/sectioning";
+ @import "@picocss/pico/scss/layout/sectioning";
````