### PR TITLE
Exclude `html` entity from aria-busy

### DIFF
--- a/scss/utilities/_loading.scss
+++ b/scss/utilities/_loading.scss
@@ -9,7 +9,7 @@
 }
 
 // Everyting except form elements
-[aria-busy="true"]:not(input, select, textarea) {
+[aria-busy="true"]:not(input, select, textarea, html) {
 
   &::before {
     display: inline-block;


### PR DESCRIPTION
When using Pico with Rails Turbo, this would cause the page to "jump" because Turbo adds the `aria-busy` attribute to the root `html` entity on a page. Pico would display a spinner, making the page jump.

Excluding it from this list makes the page not jump.