### PR TITLE
doc: target v1 default.css in v1 documentation

### DIFF
--- a/docs/customization.html
+++ b/docs/customization.html
@@ -41,7 +41,7 @@
   <i>--switch-color</i>: <u>var</u>(<i>--primary-inverse</i>);
   <i>--switch-checked-background-color</i>: <u>var</u>(<i>--primary</i>);
 }
-</code></pre><p>You can find all the CSS variables used in the default theme here: <a href="https://github.com/picocss/pico/blob/master/css/themes/default.css">css/themes/default.css</a></p><h3>Importing Pico SASS library</h3><p>We recommend customizing Pico by importing SASS source files into your project. This way, you can keep Pico up to date without conflicts since Pico code and your custom code are separated.</p><p>Compile the SASS file to CSS to get a custom version of Pico.</p><pre><code><em>/* Custom <span class="name"> </span>version */</em>
+</code></pre><p>You can find all the CSS variables used in the default theme here: <a href="https://github.com/picocss/pico/blob/v1-dev/css/themes/default.css">css/themes/default.css</a></p><h3>Importing Pico SASS library</h3><p>We recommend customizing Pico by importing SASS source files into your project. This way, you can keep Pico up to date without conflicts since Pico code and your custom code are separated.</p><p>Compile the SASS file to CSS to get a custom version of Pico.</p><pre><code><em>/* Custom <span class="name"> </span>version */</em>
 
 <em>// Override default variables</em>
 <i>$primary-500</i>: <u class="c500">…</u>;

--- a/docs/src/customization.html
+++ b/docs/src/customization.html
@@ -123,7 +123,7 @@
           <p>
             You can find all the CSS variables used in the default theme here:
             <a
-              href="https://github.com/picocss/pico/blob/master/css/themes/default.css"
+              href="https://github.com/picocss/pico/blob/v1-dev/css/themes/default.css"
               >css/themes/default.css</a
             >
           </p>


### PR DESCRIPTION
Under https://picocss.com/docs/v1/customization, there is a link the the default styles which points to https://github.com/picocss/pico/blob/main/css/themes/default.css. Due to the changes in folder structure, this file is no longer available.

![image](https://github.com/picocss/pico/assets/9423051/26172f46-ab52-4b25-99f6-c0c149d76278)

This pull request aims to use the `v1-dev` branch as the source of truth instead for v1 CSS variables.