### PR TITLE
Update _code.scss

### DIFF
--- a/scss/content/_code.scss
+++ b/scss/content/_code.scss
@@ -49,6 +49,7 @@
   #{$parent-selector} kbd {
     display: inline-block;
     padding: 0.375rem;
+    max-width: 100%;
   }
 
   #{$parent-selector} pre {


### PR DESCRIPTION
If the text is very long and does not contain spaces, the block extends beyond the parent container. The maximum width limits the off-screen behavior.
![Снимок экрана 2024-03-13 223228](https://github.com/picocss/pico/assets/18640248/00216243-beac-423d-9c46-6b1344076050)
