### PR TITLE
Add date to list of excluded input types.

### DIFF
--- a/scss/forms/_basics.scss
+++ b/scss/forms/_basics.scss
@@ -115,7 +115,7 @@
   // ––––––––––––––––––––
 
   // Force height for alternatives input types
-  #{$parent-selector} input:not([type="checkbox"], [type="radio"], [type="range"]) {
+  #{$parent-selector} input:not([type="checkbox"], [type="radio"], [type="range"], [type="date"]) {
     height: calc(
       (1rem * var(#{$css-var-prefix}line-height)) +
         (var(#{$css-var-prefix}form-element-spacing-vertical) * 2) +


### PR DESCRIPTION
Fix mismatched height in input group.

![image](https://github.com/picocss/pico/assets/6101677/f33b3167-9ca4-45e4-88be-814170b0fa91)
vs
![image](https://github.com/picocss/pico/assets/6101677/4e41b6e6-014c-4017-b340-f350ed17bd85)
