### PR TITLE
fix(docs): remove trailing slash from html5 void elements

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ There are 4 ways to get started with pico.css:
 [Download Pico](https://github.com/picocss/pico/archive/refs/heads/main.zip) and link `/css/pico.min.css` in the `<head>` of your website.
 
 ```html
-<link rel="stylesheet" href="css/pico.min.css" />
+<link rel="stylesheet" href="css/pico.min.css">
 ```
 
 ### Usage from CDN
@@ -63,7 +63,7 @@ There are 4 ways to get started with pico.css:
 Alternatively, you can use [jsDelivr CDN](https://www.jsdelivr.com/package/npm/@picocss/pico) to link pico.css.
 
 ```html
-<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@picocss/pico@2/css/pico.min.css" />
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@picocss/pico@2/css/pico.min.css">
 ```
 
 ### Install with NPM
@@ -98,7 +98,7 @@ composer require picocss/pico
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <meta name="color-scheme" content="light dark" />
+    <meta name="color-scheme" content="light dark">
     <link rel="stylesheet" href="css/pico.min.css">
     <title>Hello world!</title>
   </head>
@@ -131,7 +131,7 @@ Or use the `.fluid.classless` version if you need a fluid container:
 <link
   rel="stylesheet"
   href="https://cdn.jsdelivr.net/npm/@picocss/pico@2/css/pico.fluid.classless.min.css"
-/>
+>
 ```
 
 Then just write pure HTML, and it should look great:
@@ -140,13 +140,13 @@ Then just write pure HTML, and it should look great:
 <!doctype html>
 <html lang="en">
   <head>
-    <meta charset="utf-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <meta name="color-scheme" content="light dark" />
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="color-scheme" content="light dark">
     <link
       rel="stylesheet"
       href="https://cdn.jsdelivr.net/npm/@picocss/pico@2/css/pico.classless.min.css"
-    />
+    >
     <title>Hello, world!</title>
   </head>
   <body>


### PR DESCRIPTION
Fix #537