### PR TITLE
Allow use of card component with `role="article"`

### DIFF
--- a/scss/_index.scss
+++ b/scss/_index.scss
@@ -35,7 +35,7 @@
 
 // Components
 @use "components/accordion"; // details, summary
-@use "components/card"; // article
+@use "components/card"; // article, role="article"
 @use "components/dropdown"; // details.dropdown
 @use "components/group"; // role="group"
 @use "components/loading"; // aria-busy=true

--- a/scss/components/_card.scss
+++ b/scss/components/_card.scss
@@ -3,10 +3,11 @@
 
 @if map.get($modules, "components/card") {
   /**
-   * Card (<article>)
+   * Card (<article>, role="article")
    */
 
-  #{$parent-selector} article {
+  #{$parent-selector} article,
+  #{$parent-selector} [role="article"] {
     margin-bottom: var(#{$css-var-prefix}block-spacing-vertical);
     padding: var(#{$css-var-prefix}block-spacing-vertical)
       var(#{$css-var-prefix}block-spacing-horizontal);


### PR DESCRIPTION
Would be a welcome improvement. It's a [valid ARIA role](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/article_role) and makes things like `<fieldset role="article"><!-- ... --></fieldset>` possible. Any reasons not to do this?