### PR TITLE
fix: <small> does not have the correct size

### DIFF
--- a/scss/themes/default/_styles.scss
+++ b/scss/themes/default/_styles.scss
@@ -228,6 +228,7 @@
     // Small
     small {
       #{$css-var-prefix}font-size: 0.875em;
+      font-size: var(#{$css-var-prefix}font-size);
     }
 
     // Headings


### PR DESCRIPTION
On the <small> element, the `--pico-font-size` variable is set. But the actual `font-size` attribute is left unchanged, so the value set by the user-agent is used instead. This is `smaller`, which is slightly smaller than the `0.875em` set in the variable.

This can be fixed by simply resetting `font-size: var(--pico-font-size)`.