### PR TITLE
Fix SASS Deprecation Warning

### DIFF
--- a/scss/themes/default/_styles.scss
+++ b/scss/themes/default/_styles.scss
@@ -35,16 +35,18 @@
       }
     }
 
-    // Borders
-    #{$css-var-prefix}border-radius: 0.25rem;
-    #{$css-var-prefix}border-width: 0.0625rem;
-    #{$css-var-prefix}outline-width: 0.125rem;
+    & {
+      // Borders
+      #{$css-var-prefix}border-radius: 0.25rem;
+      #{$css-var-prefix}border-width: 0.0625rem;
+      #{$css-var-prefix}outline-width: 0.125rem;
 
-    // Transitions
-    #{$css-var-prefix}transition: 0.2s ease-in-out;
+      // Transitions
+      #{$css-var-prefix}transition: 0.2s ease-in-out;
 
-    // Spacings
-    #{$css-var-prefix}spacing: 1rem;
+      // Spacings
+      #{$css-var-prefix}spacing: 1rem;
+    }
 
     // Spacings for typography elements
     @if map.get($modules, "content/typography") {


### PR DESCRIPTION
> Sass's behavior for declarations that appear after nested
rules will be changing to match the behavior specified by CSS in an upcoming version. To keep the existing behavior, move the declaration above the nested rule. To opt into the new behavior, wrap the declaration in `& {}`.
>   
> More info: https://sass-lang.com/d/mixed-decls

There may be more locations where these changes should be made - but this one is the only one that gives an error in my codebase