### PR TITLE
fix: don't count hidden rows in table stripes

### DIFF
--- a/scss/content/_table.scss
+++ b/scss/content/_table.scss
@@ -52,8 +52,8 @@
   @if enable-classes {
     #{$parent-selector} table {
       &.striped {
-        tbody tr:nth-child(odd) th,
-        tbody tr:nth-child(odd) td {
+        tbody tr:nth-child(odd of :not([hidden])) th,
+        tbody tr:nth-child(odd of :not([hidden])) td {
           background-color: var(#{$css-var-prefix}table-row-stripped-background-color);
         }
       }


### PR DESCRIPTION
Hiding rows of a table using the `hidden` global attribute can screw up the striping because they are still counted in the odd/even rows.



This fix is straight from the [MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/:nth-child#using_of_selector_to_fix_striped_tables).