### PR TITLE
Remove dotted border on [role=button] elements with a tooltip

### DIFF
--- a/scss/components/_tooltip.scss
+++ b/scss/components/_tooltip.scss
@@ -9,7 +9,7 @@
   #{$parent-selector} [data-tooltip] {
     position: relative;
 
-    &:not(a, button, input) {
+    &:not(a, button, input, [role="button"]) {
       border-bottom: 1px dotted;
       text-decoration: none;
       cursor: help;


### PR DESCRIPTION
Any element with [role="button"] should not have a dotted bottom border.