### PR TITLE
Fix deprecation warnings for mixed declarations

### DIFF
--- a/scss/components/_accordion.scss
+++ b/scss/components/_accordion.scss
@@ -15,10 +15,6 @@
       list-style-type: none;
       cursor: pointer;
 
-      &:not([role]) {
-        color: var(#{$css-var-prefix}accordion-close-summary-color);
-      }
-
       @if $enable-transitions {
         transition: color var(#{$css-var-prefix}transition);
       }
@@ -69,6 +65,10 @@
           outline-offset: calc(var(#{$css-var-prefix}spacing, 1rem) * 0.5);
           color: var(#{$css-var-prefix}primary);
         }
+      }
+
+      &:not([role]) {
+        color: var(#{$css-var-prefix}accordion-close-summary-color);
       }
 
       // Type button

--- a/scss/themes/default/_dark.scss
+++ b/scss/themes/default/_dark.scss
@@ -137,68 +137,79 @@
     }
   }
 
-  // Switch (input[type="checkbox"][role="switch"])
-  @if map.get($modules, "forms/checkbox-radio-switch") {
-    #{$css-var-prefix}switch-background-color: #{$slate-750};
-    #{$css-var-prefix}switch-checked-background-color: var(#{$css-var-prefix}primary-background);
-    #{$css-var-prefix}switch-color: #{$white};
-    #{$css-var-prefix}switch-thumb-box-shadow: theme-colors.get("switch-thumb-box-shadow", "dark");
-  }
+  & {
+    // Switch (input[type="checkbox"][role="switch"])
+    @if map.get($modules, "forms/checkbox-radio-switch") {
+      #{$css-var-prefix}switch-background-color: #{$slate-750};
+      #{$css-var-prefix}switch-checked-background-color: var(#{$css-var-prefix}primary-background);
+      #{$css-var-prefix}switch-color: #{$white};
+      #{$css-var-prefix}switch-thumb-box-shadow: theme-colors.get("switch-thumb-box-shadow", "dark");
+    }
 
-  // Range (input[type="range"])
-  @if map.get($modules, "forms/input-range") {
-    #{$css-var-prefix}range-border-color: #{$slate-850};
-    #{$css-var-prefix}range-active-border-color: #{$slate-800};
-    #{$css-var-prefix}range-thumb-border-color: var(#{$css-var-prefix}background-color);
-    #{$css-var-prefix}range-thumb-color: var(#{$css-var-prefix}secondary-background);
-    #{$css-var-prefix}range-thumb-active-color: var(#{$css-var-prefix}primary-background);
-  }
+    // Range (input[type="range"])
+    @if map.get($modules, "forms/input-range") {
+      #{$css-var-prefix}range-border-color: #{$slate-850};
+      #{$css-var-prefix}range-active-border-color: #{$slate-800};
+      #{$css-var-prefix}range-thumb-border-color: var(#{$css-var-prefix}background-color);
+      #{$css-var-prefix}range-thumb-color: var(#{$css-var-prefix}secondary-background);
+      #{$css-var-prefix}range-thumb-active-color: var(#{$css-var-prefix}primary-background);
+    }
 
-  // Accordion (<details>)
-  @if map.get($modules, "components/accordion") {
-    #{$css-var-prefix}accordion-border-color: var(#{$css-var-prefix}muted-border-color);
-    #{$css-var-prefix}accordion-active-summary-color: var(#{$css-var-prefix}primary-hover);
-    #{$css-var-prefix}accordion-close-summary-color: var(#{$css-var-prefix}color);
-    #{$css-var-prefix}accordion-open-summary-color: var(#{$css-var-prefix}muted-color);
-  }
+    // Accordion (<details>)
+    @if map.get($modules, "components/accordion") {
+      #{$css-var-prefix}accordion-border-color: var(#{$css-var-prefix}muted-border-color);
+      #{$css-var-prefix}accordion-active-summary-color: var(#{$css-var-prefix}primary-hover);
+      #{$css-var-prefix}accordion-close-summary-color: var(#{$css-var-prefix}color);
+      #{$css-var-prefix}accordion-open-summary-color: var(#{$css-var-prefix}muted-color);
+    }
 
-  // Card (<article>)
-  @if map.get($modules, "components/card") {
-    #{$css-var-prefix}card-background-color: #{$slate-900};
-    #{$css-var-prefix}card-border-color: var(#{$css-var-prefix}card-background-color);
-    #{$css-var-prefix}card-box-shadow: var(#{$css-var-prefix}box-shadow);
-    #{$css-var-prefix}card-sectioning-background-color: #{mix($slate-900, $slate-850, 75%)};
-  }
+    // Card (<article>)
+    @if map.get($modules, "components/card") {
+      #{$css-var-prefix}card-background-color: #{$slate-900};
+      #{$css-var-prefix}card-border-color: var(#{$css-var-prefix}card-background-color);
+      #{$css-var-prefix}card-box-shadow: var(#{$css-var-prefix}box-shadow);
+      #{$css-var-prefix}card-sectioning-background-color: #{mix($slate-900, $slate-850, 75%)};
+    }
 
-  // Dropdown (details.dropdown)
-  @if map.get($modules, "components/dropdown") and $enable-classes {
-    #{$css-var-prefix}dropdown-background-color: #{$slate-900};
-    #{$css-var-prefix}dropdown-border-color: #{$slate-850};
-    #{$css-var-prefix}dropdown-box-shadow: var(#{$css-var-prefix}box-shadow);
-    #{$css-var-prefix}dropdown-color: var(#{$css-var-prefix}color);
-    #{$css-var-prefix}dropdown-hover-background-color: #{$slate-850};
-  }
+    // Dropdown (details.dropdown)
+    @if map.get($modules, "components/dropdown") and $enable-classes {
+      #{$css-var-prefix}dropdown-background-color: #{$slate-900};
+      #{$css-var-prefix}dropdown-border-color: #{$slate-850};
+      #{$css-var-prefix}dropdown-box-shadow: var(#{$css-var-prefix}box-shadow);
+      #{$css-var-prefix}dropdown-color: var(#{$css-var-prefix}color);
+      #{$css-var-prefix}dropdown-hover-background-color: #{$slate-850};
+    }
 
-  // Loading ([aria-busy=true])
-  @if map.get($modules, "components/loading") {
-    #{$css-var-prefix}loading-spinner-opacity: 0.5;
-  }
+    // Loading ([aria-busy=true])
+    @if map.get($modules, "components/loading") {
+      #{$css-var-prefix}loading-spinner-opacity: 0.5;
+    }
 
-  // Modal (<dialog>)
-  @if map.get($modules, "components/modal") {
-    #{$css-var-prefix}modal-overlay-background-color: #{rgba(mix($black, $zinc-950), 0.75)};
-  }
+    // Modal (<dialog>)
+    @if map.get($modules, "components/modal") {
+      #{$css-var-prefix}modal-overlay-background-color: #{rgba(mix($black, $zinc-950), 0.75)};
+    }
 
-  // Progress
-  @if map.get($modules, "components/progress") {
-    #{$css-var-prefix}progress-background-color: #{$slate-850};
-    #{$css-var-prefix}progress-color: var(#{$css-var-prefix}primary-background);
-  }
+    // Progress
+    @if map.get($modules, "components/progress") {
+      #{$css-var-prefix}progress-background-color: #{$slate-850};
+      #{$css-var-prefix}progress-color: var(#{$css-var-prefix}primary-background);
+    }
 
-  // Tooltip ([data-tooltip])
-  @if map.get($modules, "components/tooltip") {
-    #{$css-var-prefix}tooltip-background-color: var(#{$css-var-prefix}contrast-background);
-    #{$css-var-prefix}tooltip-color: var(#{$css-var-prefix}contrast-inverse);
+    // Tooltip ([data-tooltip])
+    @if map.get($modules, "components/tooltip") {
+      #{$css-var-prefix}tooltip-background-color: var(#{$css-var-prefix}contrast-background);
+      #{$css-var-prefix}tooltip-color: var(#{$css-var-prefix}contrast-inverse);
+    }
+
+    // Form validation icons
+    @if map.get($modules, "forms/basics") {
+      #{$css-var-prefix}icon-valid: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24' viewBox='0 0 24 24' fill='none' stroke='#{functions.display-rgb(mix($jade-450, $slate-600))}' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpolyline points='20 6 9 17 4 12'%3E%3C/polyline%3E%3C/svg%3E");
+      #{$css-var-prefix}icon-invalid: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24' viewBox='0 0 24 24' fill='none' stroke='#{functions.display-rgb(mix($red-500, $slate-600))}' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Ccircle cx='12' cy='12' r='10'%3E%3C/circle%3E%3Cline x1='12' y1='8' x2='12' y2='12'%3E%3C/line%3E%3Cline x1='12' y1='16' x2='12.01' y2='16'%3E%3C/line%3E%3C/svg%3E");
+    }
+
+    // Document
+    color-scheme: dark;
   }
 
   // Chevron icons
@@ -215,12 +226,6 @@
         }
       }
     }
-  }
-
-  // Form validation icons
-  @if map.get($modules, "forms/basics") {
-    #{$css-var-prefix}icon-valid: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24' viewBox='0 0 24 24' fill='none' stroke='#{functions.display-rgb(mix($jade-450, $slate-600))}' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpolyline points='20 6 9 17 4 12'%3E%3C/polyline%3E%3C/svg%3E");
-    #{$css-var-prefix}icon-invalid: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24' viewBox='0 0 24 24' fill='none' stroke='#{functions.display-rgb(mix($red-500, $slate-600))}' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Ccircle cx='12' cy='12' r='10'%3E%3C/circle%3E%3Cline x1='12' y1='8' x2='12' y2='12'%3E%3C/line%3E%3Cline x1='12' y1='16' x2='12.01' y2='16'%3E%3C/line%3E%3C/svg%3E");
   }
 
   // Loading icon (animated)
@@ -242,7 +247,4 @@
       }
     }
   }
-
-  // Document
-  color-scheme: dark;
 }

--- a/scss/themes/default/_light.scss
+++ b/scss/themes/default/_light.scss
@@ -137,76 +137,78 @@
     }
   }
 
-  // Switch (input[type="checkbox"][role="switch"])
-  @if map.get($modules, "forms/checkbox-radio-switch") {
-    #{$css-var-prefix}switch-background-color: #{$slate-200};
-    #{$css-var-prefix}switch-checked-background-color: var(#{$css-var-prefix}primary-background);
-    #{$css-var-prefix}switch-color: #{$white};
-    #{$css-var-prefix}switch-thumb-box-shadow: theme-colors.get("switch-thumb-box-shadow", "light");
-  }
+  & {
+    // Switch (input[type="checkbox"][role="switch"])
+    @if map.get($modules, "forms/checkbox-radio-switch") {
+      #{$css-var-prefix}switch-background-color: #{$slate-200};
+      #{$css-var-prefix}switch-checked-background-color: var(#{$css-var-prefix}primary-background);
+      #{$css-var-prefix}switch-color: #{$white};
+      #{$css-var-prefix}switch-thumb-box-shadow: theme-colors.get("switch-thumb-box-shadow", "light");
+    }
 
-  // Range (input[type="range"])
-  @if map.get($modules, "forms/input-range") {
-    #{$css-var-prefix}range-border-color: #{$slate-100};
-    #{$css-var-prefix}range-active-border-color: #{$slate-200};
-    #{$css-var-prefix}range-thumb-border-color: var(#{$css-var-prefix}background-color);
-    #{$css-var-prefix}range-thumb-color: var(#{$css-var-prefix}secondary-background);
-    #{$css-var-prefix}range-thumb-active-color: var(#{$css-var-prefix}primary-background);
-  }
+    // Range (input[type="range"])
+    @if map.get($modules, "forms/input-range") {
+      #{$css-var-prefix}range-border-color: #{$slate-100};
+      #{$css-var-prefix}range-active-border-color: #{$slate-200};
+      #{$css-var-prefix}range-thumb-border-color: var(#{$css-var-prefix}background-color);
+      #{$css-var-prefix}range-thumb-color: var(#{$css-var-prefix}secondary-background);
+      #{$css-var-prefix}range-thumb-active-color: var(#{$css-var-prefix}primary-background);
+    }
 
-  // Accordion (<details>)
-  @if map.get($modules, "components/accordion") {
-    #{$css-var-prefix}accordion-border-color: var(#{$css-var-prefix}muted-border-color);
-    #{$css-var-prefix}accordion-active-summary-color: var(#{$css-var-prefix}primary-hover);
-    #{$css-var-prefix}accordion-close-summary-color: var(#{$css-var-prefix}color);
-    #{$css-var-prefix}accordion-open-summary-color: var(#{$css-var-prefix}muted-color);
-  }
+    // Accordion (<details>)
+    @if map.get($modules, "components/accordion") {
+      #{$css-var-prefix}accordion-border-color: var(#{$css-var-prefix}muted-border-color);
+      #{$css-var-prefix}accordion-active-summary-color: var(#{$css-var-prefix}primary-hover);
+      #{$css-var-prefix}accordion-close-summary-color: var(#{$css-var-prefix}color);
+      #{$css-var-prefix}accordion-open-summary-color: var(#{$css-var-prefix}muted-color);
+    }
 
-  // Card (<article>)
-  @if map.get($modules, "components/card") {
-    #{$css-var-prefix}card-background-color: var(#{$css-var-prefix}background-color);
-    #{$css-var-prefix}card-border-color: var(#{$css-var-prefix}muted-border-color);
-    #{$css-var-prefix}card-box-shadow: var(#{$css-var-prefix}box-shadow);
-    #{$css-var-prefix}card-sectioning-background-color: #{mix($slate-50, $white, 25%)};
-  }
+    // Card (<article>)
+    @if map.get($modules, "components/card") {
+      #{$css-var-prefix}card-background-color: var(#{$css-var-prefix}background-color);
+      #{$css-var-prefix}card-border-color: var(#{$css-var-prefix}muted-border-color);
+      #{$css-var-prefix}card-box-shadow: var(#{$css-var-prefix}box-shadow);
+      #{$css-var-prefix}card-sectioning-background-color: #{mix($slate-50, $white, 25%)};
+    }
 
-  // Dropdown (details.dropdown)
-  @if map.get($modules, "components/dropdown") and $enable-classes {
-    #{$css-var-prefix}dropdown-background-color: #{$white};
-    #{$css-var-prefix}dropdown-border-color: #{$slate-50};
-    #{$css-var-prefix}dropdown-box-shadow: var(#{$css-var-prefix}box-shadow);
-    #{$css-var-prefix}dropdown-color: var(#{$css-var-prefix}color);
-    #{$css-var-prefix}dropdown-hover-background-color: #{$slate-50};
-  }
+    // Dropdown (details.dropdown)
+    @if map.get($modules, "components/dropdown") and $enable-classes {
+      #{$css-var-prefix}dropdown-background-color: #{$white};
+      #{$css-var-prefix}dropdown-border-color: #{$slate-50};
+      #{$css-var-prefix}dropdown-box-shadow: var(#{$css-var-prefix}box-shadow);
+      #{$css-var-prefix}dropdown-color: var(#{$css-var-prefix}color);
+      #{$css-var-prefix}dropdown-hover-background-color: #{$slate-50};
+    }
 
-  // Loading ([aria-busy=true])
-  @if map.get($modules, "components/loading") {
-    #{$css-var-prefix}loading-spinner-opacity: 0.5;
-  }
+    // Loading ([aria-busy=true])
+    @if map.get($modules, "components/loading") {
+      #{$css-var-prefix}loading-spinner-opacity: 0.5;
+    }
 
-  // Modal (<dialog>)
-  @if map.get($modules, "components/modal") {
-    #{$css-var-prefix}modal-overlay-background-color: #{rgba(mix($zinc-100, $zinc-50), 0.75)};
-  }
+    // Modal (<dialog>)
+    @if map.get($modules, "components/modal") {
+      #{$css-var-prefix}modal-overlay-background-color: #{rgba(mix($zinc-100, $zinc-50), 0.75)};
+    }
 
-  // Progress
-  @if map.get($modules, "components/progress") {
-    #{$css-var-prefix}progress-background-color: #{$slate-100};
-    #{$css-var-prefix}progress-color: var(#{$css-var-prefix}primary-background);
-  }
+    // Progress
+    @if map.get($modules, "components/progress") {
+      #{$css-var-prefix}progress-background-color: #{$slate-100};
+      #{$css-var-prefix}progress-color: var(#{$css-var-prefix}primary-background);
+    }
 
-  // Tooltip ([data-tooltip])
-  @if map.get($modules, "components/tooltip") {
-    #{$css-var-prefix}tooltip-background-color: var(#{$css-var-prefix}contrast-background);
-    #{$css-var-prefix}tooltip-color: var(#{$css-var-prefix}contrast-inverse);
-  }
+    // Tooltip ([data-tooltip])
+    @if map.get($modules, "components/tooltip") {
+      #{$css-var-prefix}tooltip-background-color: var(#{$css-var-prefix}contrast-background);
+      #{$css-var-prefix}tooltip-color: var(#{$css-var-prefix}contrast-inverse);
+    }
 
-  // Form validation icons
-  @if map.get($modules, "forms/basics") {
-    #{$css-var-prefix}icon-valid: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24' viewBox='0 0 24 24' fill='none' stroke='#{functions.display-rgb(mix($jade-450, $zinc-350))}' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpolyline points='20 6 9 17 4 12'%3E%3C/polyline%3E%3C/svg%3E");
-    #{$css-var-prefix}icon-invalid: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24' viewBox='0 0 24 24' fill='none' stroke='#{functions.display-rgb(mix($red-500, $zinc-350, 75%))}' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Ccircle cx='12' cy='12' r='10'%3E%3C/circle%3E%3Cline x1='12' y1='8' x2='12' y2='12'%3E%3C/line%3E%3Cline x1='12' y1='16' x2='12.01' y2='16'%3E%3C/line%3E%3C/svg%3E");
-  }
+    // Form validation icons
+    @if map.get($modules, "forms/basics") {
+      #{$css-var-prefix}icon-valid: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24' viewBox='0 0 24 24' fill='none' stroke='#{functions.display-rgb(mix($jade-450, $zinc-350))}' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpolyline points='20 6 9 17 4 12'%3E%3C/polyline%3E%3C/svg%3E");
+      #{$css-var-prefix}icon-invalid: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24' viewBox='0 0 24 24' fill='none' stroke='#{functions.display-rgb(mix($red-500, $zinc-350, 75%))}' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Ccircle cx='12' cy='12' r='10'%3E%3C/circle%3E%3Cline x1='12' y1='8' x2='12' y2='12'%3E%3C/line%3E%3Cline x1='12' y1='16' x2='12.01' y2='16'%3E%3C/line%3E%3C/svg%3E");
+    }
 
-  // Document
-  color-scheme: light;
+    // Document
+    color-scheme: light;
+  }
 }

--- a/scss/themes/default/_styles.scss
+++ b/scss/themes/default/_styles.scss
@@ -24,17 +24,6 @@
     #{$css-var-prefix}font-size: 100%;
     #{$css-var-prefix}text-underline-offset: 0.1rem;
 
-    // Responsive root font size
-    @if $enable-responsive-typography {
-      @each $key, $values in $breakpoints {
-        @if $values {
-          @media (min-width: map.get($values, "breakpoint")) {
-            #{$css-var-prefix}font-size: map.get($values, "root-font-size");
-          }
-        }
-      }
-    }
-
     // Borders
     #{$css-var-prefix}border-radius: 0.25rem;
     #{$css-var-prefix}border-width: 0.0625rem;
@@ -140,6 +129,17 @@
     @if map.get($modules, "components/loading") {
       // Inspired by https://codepen.io/aleksander351/pen/KzgKPo
       #{$css-var-prefix}icon-loading: url("data:image/svg+xml,%3Csvg fill='none' height='24' width='24' viewBox='0 0 24 24' xmlns='http://www.w3.org/2000/svg' %3E%3Cstyle%3E g %7B animation: rotate 2s linear infinite; transform-origin: center center; %7D circle %7B stroke-dasharray: 75,100; stroke-dashoffset: -5; animation: dash 1.5s ease-in-out infinite; stroke-linecap: round; %7D @keyframes rotate %7B 0%25 %7B transform: rotate(0deg); %7D 100%25 %7B transform: rotate(360deg); %7D %7D @keyframes dash %7B 0%25 %7B stroke-dasharray: 1,100; stroke-dashoffset: 0; %7D 50%25 %7B stroke-dasharray: 44.5,100; stroke-dashoffset: -17.5; %7D 100%25 %7B stroke-dasharray: 44.5,100; stroke-dashoffset: -62; %7D %7D %3C/style%3E%3Cg%3E%3Ccircle cx='12' cy='12' r='10' fill='none' stroke='#{functions.display-rgb($zinc-400)}' stroke-width='4' /%3E%3C/g%3E%3C/svg%3E");
+    }
+
+    // Responsive root font size
+    @if $enable-responsive-typography {
+      @each $key, $values in $breakpoints {
+        @if $values {
+          @media (min-width: map.get($values, "breakpoint")) {
+            #{$css-var-prefix}font-size: map.get($values, "root-font-size");
+          }
+        }
+      }
     }
   }
 


### PR DESCRIPTION
Fixes #577 

Current versions of sass now emit a deprecation warning about mixed declarations. Essentially, this just means that direct declarations need to either:
* come before nested declarations
* be included in an `&`, which effectively "reopens" the enclosing scope

https://sass-lang.com/documentation/breaking-changes/mixed-decls/