### PR TITLE
Update _loading.scss not to affect form elements itself

### DIFF
--- a/scss/components/_loading.scss
+++ b/scss/components/_loading.scss
@@ -7,7 +7,7 @@
    */
 
   // Everything except form elements
-  #{$parent-selector} [aria-busy="true"]:not(input, select, textarea, html) {
+  #{$parent-selector} [aria-busy="true"]:not(input, select, textarea, html, form) {
     white-space: nowrap;
 
     &::before {


### PR DESCRIPTION
Some web frameworks such as Rails mark the form element as `aria-busy="true"` while the form is submitted.

This PR will exclude the form tag from being affected from the loading indicator.