### PR TITLE
Only apply vertical nav styling to elements inside <nav>

### DIFF
--- a/scss/components/_nav.scss
+++ b/scss/components/_nav.scss
@@ -120,8 +120,8 @@
   }
 
   // Vertical Nav
-  #{$parent-selector} aside {
-    nav,
+  #{$parent-selector} aside nav {
+    &,
     ol,
     ul,
     li {


### PR DESCRIPTION
This enables <aside> to be used for other purposes, without vertical nav styling interfering.

(I will generate the CSS files once this PR has been approved in concept.)