### PR TITLE
Striped table rows cleancss fix

### DIFF
--- a/scss/content/_table.scss
+++ b/scss/content/_table.scss
@@ -50,13 +50,13 @@
 
   // Striped
   @if enable-classes {
-    #{$parent-selector} table {
-      &.striped {
-        tbody tr:nth-child(odd) th,
-        tbody tr:nth-child(odd) td {
-          background-color: var(#{$css-var-prefix}table-row-stripped-background-color);
-        }
+    /* clean-css ignore:start */
+    #{$parent-selector} table.striped {
+      tbody tr:nth-child(odd of :not([hidden])) th,
+      tbody tr:nth-child(odd of :not([hidden])) td {
+        background-color: var(#{$css-var-prefix}table-row-stripped-background-color);
       }
     }
+    /* clean-css ignore:end */
   }
 }

--- a/scss/content/_table.scss
+++ b/scss/content/_table.scss
@@ -50,13 +50,13 @@
 
   // Striped
   @if enable-classes {
-    /* clean-css ignore:start */
     #{$parent-selector} table.striped {
-      tbody tr:nth-child(odd of :not([hidden])) th,
-      tbody tr:nth-child(odd of :not([hidden])) td {
-        background-color: var(#{$css-var-prefix}table-row-stripped-background-color);
+      tbody tr:is(:nth-child(odd of :not([hidden]))) {
+        th,
+        td {
+          background-color: var(#{$css-var-prefix}table-row-stripped-background-color);
+        }
       }
     }
-    /* clean-css ignore:end */
   }
 }


### PR DESCRIPTION
Its a little dirty, but it works. CleanCSS was causing the issue, and we can tell it to not modify that code block. I tried it a few different ways before I settings with this.