### PR TITLE
feat: support ordered list breadcrumb

### DIFF
--- a/scss/components/_nav.scss
+++ b/scss/components/_nav.scss
@@ -84,7 +84,8 @@
       align-items: center;
       justify-content: start;
 
-      & ul li {
+      & ul li,
+      & ol li {
         &:not(:first-child) {
           margin-inline-start: var(#{$css-var-prefix}nav-link-spacing-horizontal);
         }
@@ -147,7 +148,8 @@
   [dir="rtl"] {
     #{$parent-selector} nav {
       &[aria-label="breadcrumb"] {
-        & ul li {
+        & ul li,
+        & ol li {
           &:not(:last-child) {
             ::after {
               content: "\\";


### PR DESCRIPTION
## Context

As mentioned in the [ARIA Authoring Practices Guide](https://www.w3.org/WAI/ARIA/apg/patterns/breadcrumb/), a breadcrumb trail represents page hierarchy, which implies some type of order. Hence, the suggested implementation for a breadcrumb trail is to use an ordered list (`ol`).

However, Pico CSS only applies breadcrumb styles to unordered lists (`ul`).

## This PR

* Updates breadcrumb styles to apply to both `ul` and `ol` elements.