### PR TITLE
Allow Breadcrumb to have uppercase B

### DIFF
--- a/scss/components/_nav.scss
+++ b/scss/components/_nav.scss
@@ -80,7 +80,8 @@
     }
 
     // Breadcrumb
-    &[aria-label="breadcrumb"] {
+    &[aria-label="breadcrumb"],
+    &[aria-label="Breadcrumb"] {
       align-items: center;
       justify-content: start;
 


### PR DESCRIPTION
In many docs and HTML in the wild is `Breadcrumb` written with a uppercase `B`. 

- https://developer.mozilla.org/en-US/docs/Web/CSS/Layout_cookbook/Breadcrumb_Navigation
- https://www.w3.org/WAI/ARIA/apg/patterns/breadcrumb/examples/breadcrumb/