### PR TITLE
Fix dropdown summary ul offscreen

### DIFF
--- a/css/pico.css
+++ b/css/pico.css
@@ -2099,7 +2099,7 @@ details.dropdown > summary + ul {
   display: flex;
   z-index: 99;
   position: absolute;
-  left: 0;
+  right: 0;
   flex-direction: column;
   width: 100%;
   min-width: -moz-fit-content;


### PR DESCRIPTION
The navigation dropdown is set to `position:absolute` and `left:0` with `nowrap`.

This causes text to render offscreen in mobile.

This fix replaces `left:0` with `right:0` so content does not flow offscreen.